### PR TITLE
Marshal/Unmarshal methods for uint64 view type, and for bytes too

### DIFF
--- a/conv/bytes.go
+++ b/conv/bytes.go
@@ -1,0 +1,29 @@
+package conv
+
+import (
+	"encoding/hex"
+	"fmt"
+)
+
+func BytesMarshalText(b []byte) ([]byte, error) {
+	l := 2 + (len(b) * 2)
+	res := make([]byte, l, l)
+	res[0] = '0'
+	res[1] = 'x'
+	hex.Encode(res[2:], b)
+	return res, nil
+}
+
+func FixedBytesUnmarshalText(dst []byte, text []byte) error {
+	if dst == nil {
+		return DestNilErr
+	}
+	if len(text) >= 2 && text[0] == '0' && (text[1] == 'x' || text[1] == 'X') {
+		text = text[2:]
+	}
+	if len(text) != 2*len(dst) {
+		return fmt.Errorf("unexpected length %d, expected %d, got string '%s'", len(text), len(dst), string(text))
+	}
+	_, err := hex.Decode(dst, text)
+	return err
+}

--- a/conv/numbers.go
+++ b/conv/numbers.go
@@ -17,8 +17,8 @@ func Uint64Unmarshal(v *uint64, b []byte) error {
 	if len(b) == 0 {
 		return EmptyInputErr
 	}
-	if b[0] == '"' {
-		if len(b) == 1 || b[len(b)-1] != '"' {
+	if b[0] == '"' || b[0] == '\'' {
+		if len(b) == 1 || b[len(b)-1] != b[0] {
 			return MissingQuoteErr
 		}
 		b = b[1 : len(b)-1]

--- a/conv/numbers.go
+++ b/conv/numbers.go
@@ -1,0 +1,41 @@
+package conv
+
+import (
+	"errors"
+	"strconv"
+)
+
+var DestNilErr = errors.New("destination is nil")
+var EmptyInputErr = errors.New("input is empty")
+var MissingQuoteErr = errors.New("input has quote open without close")
+
+// Parse a uint64, with or without quotes, in any base, with common prefixes accepted to change base.
+func Uint64Unmarshal(v *uint64, b []byte) error {
+	if v == nil {
+		return DestNilErr
+	}
+	if len(b) == 0 {
+		return EmptyInputErr
+	}
+	if b[0] == '"' {
+		if len(b) == 1 || b[len(b)-1] != '"' {
+			return MissingQuoteErr
+		}
+		b = b[1 : len(b)-1]
+	}
+	n, err := strconv.ParseUint(string(b), 0, 64)
+	if err != nil {
+		return err
+	}
+	*v = n
+	return nil
+}
+
+// Marshal a uint64, with quotes
+func Uint64Marshal(v uint64) ([]byte, error) {
+	var dest [18]byte
+	dest[0] = '"'
+	res := strconv.AppendUint(dest[0:1], v, 10)
+	res = append(res, '"')
+	return res, nil
+}

--- a/tree/root.go
+++ b/tree/root.go
@@ -5,12 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"github.com/protolambda/ztyp/codec"
+	"github.com/protolambda/ztyp/conv"
 )
 
 type Root [32]byte
 
 func (r Root) MarshalText() ([]byte, error) {
-	return []byte("0x" + hex.EncodeToString(r[:])), nil
+	return conv.BytesMarshalText(r[:])
 }
 
 func (r Root) String() string {
@@ -42,17 +43,7 @@ func (r Root) HashTreeRoot(_ HashFn) Root {
 }
 
 func (r *Root) UnmarshalText(text []byte) error {
-	if r == nil {
-		return errors.New("cannot decode into nil Root")
-	}
-	if len(text) >= 2 && text[0] == '0' && (text[1] == 'x' || text[1] == 'X') {
-		text = text[2:]
-	}
-	if len(text) != 64 {
-		return fmt.Errorf("unexpected length string '%s'", string(text))
-	}
-	_, err := hex.Decode(r[:], text)
-	return err
+	return conv.FixedBytesUnmarshalText(r[:], text)
 }
 
 func (r *Root) Left() (Node, error) {

--- a/view/basic.go
+++ b/view/basic.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/protolambda/ztyp/codec"
+	"github.com/protolambda/ztyp/conv"
 	. "github.com/protolambda/ztyp/tree"
 )
 
@@ -498,6 +499,14 @@ func (v Uint64View) HashTreeRoot(h HashFn) Root {
 
 func (v Uint64View) Type() TypeDef {
 	return Uint64Type
+}
+
+func (v Uint64View) MarshalJSON() ([]byte, error) {
+	return conv.Uint64Marshal(uint64(v))
+}
+
+func (v *Uint64View) UnmarshalJSON(b []byte) error {
+	return conv.Uint64Unmarshal((*uint64)(v), b)
 }
 
 type BoolMeta uint8

--- a/view/basic_test.go
+++ b/view/basic_test.go
@@ -90,7 +90,7 @@ func TestUint64View_UnmarshalJSON(t *testing.T) {
 		})
 	}
 	bad := []string{
-		``, `"`, `""`, `''`, `""0""`, `"0""`, `""0"`,
+		``, `"`, `""`, `''`, `""0""`, `"0""`, `""0"`, `"0'`, `'0'"`, `""0''`,
 		"00x0", "00x0", "0x", "0b", "-0", "-123", "0x1FFFFFFFFFFFFFFFF", "FFFFFFFFFFFFFFFF", "-a", "-0xab",
 	}
 	for _, b := range bad {

--- a/view/basic_test.go
+++ b/view/basic_test.go
@@ -91,7 +91,7 @@ func TestUint64View_UnmarshalJSON(t *testing.T) {
 	}
 	bad := []string{
 		``, `"`, `""`, `''`, `""0""`, `"0""`, `""0"`,
-		"0x", "0b", "-0", "-123", "0x1FFFFFFFFFFFFFFFF", "FFFFFFFFFFFFFFFF", "-a", "-0xab",
+		"00x0", "00x0", "0x", "0b", "-0", "-123", "0x1FFFFFFFFFFFFFFFF", "FFFFFFFFFFFFFFFF", "-a", "-0xab",
 	}
 	for _, b := range bad {
 		t.Run(b, func(t *testing.T) {

--- a/view/basic_test.go
+++ b/view/basic_test.go
@@ -1,0 +1,104 @@
+package view
+
+import "testing"
+
+func TestUint64View_MarshalJSON(t *testing.T) {
+	cases := []struct {
+		n uint64
+		s string
+	}{
+		{0, "0"},
+		{1, "1"},
+		{1234, "1234"},
+		{uint64(1) << 63, "9223372036854775808"},
+		{^uint64(0), "18446744073709551615"},
+	}
+	for _, c := range cases {
+		t.Run(c.s, func(t *testing.T) {
+			v, err := Uint64View(c.n).MarshalJSON()
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if string(v) != `"`+c.s+`"` {
+				t.Errorf("unexpected value: %s", string(v))
+			}
+		})
+	}
+}
+
+func TestUint64View_UnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		n uint64
+		s string
+	}{
+		{0, "0"},
+		{0, "0b0"},
+		{0, "0x0"},
+		{0, "0x00"},
+		{0, "0x0000"},
+		{0, "000"},
+		{1, "1"},
+		{1234, "1234"},
+		{0xc0fFeE, "0xc0fFeE"},
+		{0b10101011, "0b10101011"},
+		{uint64(1) << 63, "9223372036854775808"},
+		{^uint64(0), "18446744073709551615"},
+		{^uint64(0), "0xFFFFFFFFFFFFFFFF"},
+		{^uint64(0), "0x0FFFFFFFFFFFFFFFF"},
+		{^uint64(0), "0x00FFFFFFFFFFFFFFFF"},
+	}
+	for _, c := range cases {
+		t.Run(c.s+"_unquoted", func(t *testing.T) {
+			expected := Uint64View(c.n)
+			var res Uint64View
+			err := res.UnmarshalJSON([]byte(c.s))
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if res != expected {
+				t.Errorf("unexpected value: %v", res)
+			}
+		})
+		t.Run(c.s+"_double_quoted", func(t *testing.T) {
+			expected := Uint64View(c.n)
+			var res Uint64View
+			b := []byte{'"'}
+			b = append(b, c.s...)
+			b = append(b, '"')
+			err := res.UnmarshalJSON(b)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if res != expected {
+				t.Errorf("unexpected value: %v", res)
+			}
+		})
+		// technically not valid, but still useful
+		t.Run(c.s+"_single_quoted", func(t *testing.T) {
+			expected := Uint64View(c.n)
+			var res Uint64View
+			b := []byte{'\''}
+			b = append(b, c.s...)
+			b = append(b, '\'')
+			err := res.UnmarshalJSON(b)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if res != expected {
+				t.Errorf("unexpected value: %v", res)
+			}
+		})
+	}
+	bad := []string{
+		``, `"`, `""`, `''`, `""0""`, `"0""`, `""0"`,
+		"0x", "0b", "-0", "-123", "0x1FFFFFFFFFFFFFFFF", "FFFFFFFFFFFFFFFF", "-a", "-0xab",
+	}
+	for _, b := range bad {
+		t.Run(b, func(t *testing.T) {
+			var res Uint64View
+			if err := res.UnmarshalJSON([]byte(b)); err == nil {
+				t.Errorf("expected error, but got value %d", uint64(res))
+			}
+		})
+	}
+}

--- a/view/root.go
+++ b/view/root.go
@@ -105,8 +105,8 @@ func (r *RootView) HashTreeRoot(h HashFn) Root {
 	return Root(*r)
 }
 
-func (r *RootView) MarshalText(b []byte) ([]byte, error) {
-	return conv.BytesMarshalText(b)
+func (r *RootView) MarshalText() ([]byte, error) {
+	return conv.BytesMarshalText(r[:])
 }
 
 func (r *RootView) UnmarshalText(text []byte) error {

--- a/view/root.go
+++ b/view/root.go
@@ -3,6 +3,7 @@ package view
 import (
 	"fmt"
 	"github.com/protolambda/ztyp/codec"
+	"github.com/protolambda/ztyp/conv"
 	. "github.com/protolambda/ztyp/tree"
 )
 
@@ -102,4 +103,12 @@ func (r *RootView) Serialize(w *codec.EncodingWriter) error {
 
 func (r *RootView) HashTreeRoot(h HashFn) Root {
 	return Root(*r)
+}
+
+func (r *RootView) MarshalText(b []byte) ([]byte, error) {
+	return conv.BytesMarshalText(b)
+}
+
+func (r *RootView) UnmarshalText(text []byte) error {
+	return conv.FixedBytesUnmarshalText(r[:], text)
 }

--- a/view/root_test.go
+++ b/view/root_test.go
@@ -1,0 +1,56 @@
+package view
+
+import "testing"
+
+func TestRootView_MarshalText(t *testing.T) {
+	r := RootView{0: 0xab, 31: 0x12}
+	s, err := r.MarshalText()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if string(s) != "0xab00000000000000000000000000000000000000000000000000000000000012" {
+		t.Errorf("unexpected string: %s", string(s))
+	}
+}
+
+func TestRootView_UnmarshalText(t *testing.T) {
+	cases := []struct {
+		r RootView
+		s string
+	}{
+		{RootView{0: 0xab, 31: 0x12}, "ab00000000000000000000000000000000000000000000000000000000000012"},
+		{RootView{0: 0xab, 31: 0x12}, "0Xab00000000000000000000000000000000000000000000000000000000000012"},
+		{RootView{0: 0xab, 31: 0x12}, "0xab00000000000000000000000000000000000000000000000000000000000012"},
+		{RootView{}, "0000000000000000000000000000000000000000000000000000000000000000"},
+		{RootView{}, "0x0000000000000000000000000000000000000000000000000000000000000000"},
+	}
+	for _, c := range cases {
+		t.Run(c.s, func(t *testing.T) {
+			var root RootView
+			if err := root.UnmarshalText([]byte(c.s)); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if root != c.r {
+				t.Errorf("unexpected root: %x", root[:])
+			}
+		})
+	}
+	bad := []string{
+		// no quotes. It's marshalText, not raw JSON.
+		`""`, `"0x0000000000000000000000000000000000000000000000000000000000000000"`,
+		"00000000000000000000000000000000000000000000000000000000000000000", // 1 zero extra
+		"00x00000000000000000000000000000000000000000000000000000000000000000",
+		"00x0000000000000000000000000000000000000000000000000000000000000000",
+		"00000000000000000000000000000000000000000000000000000000000000000x",
+		"0x000x00000000000000000000000000000000000000000000000000000000000000",
+		"0x0g00000000000000000000000000000000000000000000000000000000000012",
+	}
+	for _, b := range bad {
+		t.Run(b, func(t *testing.T) {
+			var root RootView
+			if err := root.UnmarshalText([]byte(b)); err == nil {
+				t.Errorf("expected error, but got root %x", root[:])
+			}
+		})
+	}
+}

--- a/view/small_byte_vec.go
+++ b/view/small_byte_vec.go
@@ -109,8 +109,8 @@ func (v SmallByteVecView) Type() TypeDef {
 	return SmallByteVecMeta(len(v))
 }
 
-func (v SmallByteVecView) MarshalText(b []byte) ([]byte, error) {
-	return conv.BytesMarshalText(b)
+func (v SmallByteVecView) MarshalText() ([]byte, error) {
+	return conv.BytesMarshalText(v)
 }
 
 func (v SmallByteVecView) UnmarshalText(text []byte) error {

--- a/view/small_byte_vec.go
+++ b/view/small_byte_vec.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/protolambda/ztyp/codec"
+	"github.com/protolambda/ztyp/conv"
 	. "github.com/protolambda/ztyp/tree"
 )
 
@@ -106,6 +107,14 @@ func (v SmallByteVecView) HashTreeRoot(h HashFn) Root {
 
 func (v SmallByteVecView) Type() TypeDef {
 	return SmallByteVecMeta(len(v))
+}
+
+func (v SmallByteVecView) MarshalText(b []byte) ([]byte, error) {
+	return conv.BytesMarshalText(b)
+}
+
+func (v SmallByteVecView) UnmarshalText(text []byte) error {
+	return conv.FixedBytesUnmarshalText(v, text)
 }
 
 const Bytes4Type SmallByteVecMeta = 4


### PR DESCRIPTION
To make numbers usable with API responses, with or without the quotes.
