### PR TITLE
Add merkle-proof generation/verification

### DIFF
--- a/tree/gindex.go
+++ b/tree/gindex.go
@@ -10,6 +10,8 @@ type Gindex interface {
 	Subtree() Gindex
 	// Anchor of the gindex: same depth, but with position zeroed out.
 	Anchor() Gindex
+	// Index of the element at the base of the tree
+	BaseIndex() uint64
 	// Left child gindex
 	Left() Gindex
 	// Right child gindex
@@ -65,6 +67,11 @@ func (v Gindex64) Subtree() Gindex {
 
 func (v Gindex64) Anchor() Gindex {
 	return Gindex64(1 << BitIndex(uint64(v)))
+}
+
+func (v Gindex64) BaseIndex() uint64 {
+	anchor := Gindex64(1 << BitIndex(uint64(v)))
+	return uint64(v ^ anchor)
 }
 
 func (v Gindex64) Left() Gindex {

--- a/tree/gindex.go
+++ b/tree/gindex.go
@@ -22,6 +22,8 @@ type Gindex interface {
 	Parent() Gindex
 	// If the gindex points into the left subtree (2nd bit is 0)
 	IsLeft() bool
+	// If the gindex points to a leaf that is the left child of its parent (Last bit is 0)
+	IsLeftLeaf() bool
 	// If the gindex is the root (= 1)
 	IsRoot() bool
 	// If gindex is 2 or 3
@@ -96,6 +98,10 @@ func (v Gindex64) Parent() Gindex {
 func (v Gindex64) IsLeft() bool {
 	pivot := Gindex64(1<<BitIndex(uint64(v))) >> 1
 	return v&pivot == 0
+}
+
+func (v Gindex64) IsLeftLeaf() bool {
+	return v&1 == 0
 }
 
 func (v Gindex64) IsRoot() bool {

--- a/tree/gindex.go
+++ b/tree/gindex.go
@@ -77,11 +77,7 @@ func (v Gindex64) Sibling() Gindex {
 	if v <= 1 {
 		panic("cannot get sibling of root")
 	}
-	if v%2 == 0 {
-		return v + 1
-	} else {
-		return v - 1
-	}
+	return v ^ 1
 }
 
 func (v Gindex64) Parent() Gindex {

--- a/tree/gindex_test.go
+++ b/tree/gindex_test.go
@@ -99,3 +99,29 @@ func TestGindex64Proof(t *testing.T) {
 		}
 	}
 }
+
+func TestGindex64Split(t *testing.T) {
+	cases := []struct {
+		gindex          Gindex64
+		depth           uint32
+		expectedGindex1 Gindex64
+		expectedGindex2 Gindex64
+	}{
+		{221184, 0, 1, 221184},
+		{221184, 4, 27, 8192},
+		{212992, 4, 26, 8192},
+		{221183, 4, 26, 16383},
+		{27, 4, 27, 1},
+	}
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			idx1, idx2 := c.gindex.Split(c.depth)
+			if idx1 != c.expectedGindex1 {
+				t.Errorf("got %d, expected %d", idx1, c.expectedGindex1)
+			}
+			if idx2 != c.expectedGindex2 {
+				t.Errorf("got %d, expected %d", idx2, c.expectedGindex2)
+			}
+		})
+	}
+}

--- a/tree/gindex_test.go
+++ b/tree/gindex_test.go
@@ -44,3 +44,58 @@ func TestGindex64_Encoding(t *testing.T) {
 		})
 	}
 }
+
+func TestToGindex64(t *testing.T) {
+	cases := []struct {
+		index         uint64
+		limit         uint64
+		expectedDepth uint8
+		expectedGi    Gindex64
+	}{
+		{11, 11, 4, 27},
+	}
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			depth := CoverDepth(c.limit)
+			if depth != c.expectedDepth {
+				t.Errorf("got %d, expected %d", depth, c.expectedDepth)
+			}
+			gi, err := ToGindex64(c.index, depth)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if gi != c.expectedGi {
+				t.Errorf("got %d, expected %d", gi, c.expectedGi)
+			}
+		})
+	}
+}
+
+func TestGindex64Proof(t *testing.T) {
+	cases := []struct {
+		gindex1 Gindex64
+		gindex2 Gindex64
+		isProof bool
+	}{
+		{8, 15, false},
+		{8, 14, false},
+		{8, 13, false},
+		{8, 12, false},
+		{8, 11, false},
+		{8, 10, false},
+		{8, 9, true},
+		{8, 8, false},
+		{8, 7, false},
+		{8, 6, false},
+		{8, 5, true},
+		{8, 4, false},
+		{8, 3, true},
+		{8, 2, false},
+		{8, 1, true},
+	}
+	for _, c := range cases {
+		if c.gindex2.IsProof(c.gindex1) != c.isProof {
+			t.Errorf("got %v, expected %v", c.gindex2.IsProof(c.gindex1), c.isProof)
+		}
+	}
+}

--- a/tree/hashing.go
+++ b/tree/hashing.go
@@ -12,9 +12,16 @@ type HTR interface {
 	HashTreeRoot(h HashFn) Root
 }
 
+type HTP interface {
+	HTR
+	HashTreeProof(h HashFn, index Gindex) []Root
+}
+
 type SeriesHTR func(i uint64) HTR
+type SeriesHTP func(i uint64) HTP
 
 type ChunksHTR func(i uint64) Root
+type ChunksHTP func(i uint64, index Gindex) []Root
 
 type HashFn func(a Root, b Root) Root
 
@@ -37,10 +44,39 @@ func (h HashFn) HashTreeRoot(fields ...HTR) Root {
 	}
 }
 
-func (h HashFn) HashTreeProof(index Gindex, fields ...HTR) ([]Root, error) {
+func (h HashFn) HashTreeProof(index Gindex, fields ...HTP) []Root {
 	return MerkleProof(h, uint64(len(fields)), uint64(len(fields)), index, func(i uint64) Root {
 		return fields[i].HashTreeRoot(h)
+	}, func(i uint64, gIndex Gindex) []Root {
+		return fields[i].HashTreeProof(h, gIndex)
 	})
+}
+
+type rootProof struct {
+	Root *Root
+}
+
+func (r rootProof) HashTreeRoot(_ HashFn) Root {
+	if r.Root == nil {
+		return Root{}
+	}
+	return *r.Root
+}
+
+func (r rootProof) HashTreeProof(_ HashFn, _ Gindex) []Root {
+	return nil
+}
+
+func RootProof(root *Root) HTP {
+	if root == nil {
+		root = &Root{}
+	}
+	return rootProof{root}
+}
+
+func NilProofFunc(_ uint64, _ Gindex) []Root {
+	// Used for structures that we cannot recurse into, like a list of bytes.
+	return nil
 }
 
 func (h HashFn) SeriesRootFunc(series SeriesHTR) func(i uint64) Root {
@@ -53,28 +89,41 @@ func (h HashFn) SeriesRootFunc(series SeriesHTR) func(i uint64) Root {
 	}
 }
 
+func (h HashFn) SeriesProofFunc(series SeriesHTP) func(i uint64, gIndex Gindex) []Root {
+	return func(i uint64, gIndex Gindex) []Root {
+		htp := series(i)
+		if htp == nil { // missing element? Fine, just like an empty node then
+			return []Root{}
+		}
+		return htp.HashTreeProof(h, gIndex)
+	}
+}
+
 func (h HashFn) ComplexVectorHTR(series SeriesHTR, length uint64) Root {
 	// length is alos limit for vectors
 	return Merkleize(h, length, length, h.SeriesRootFunc(series))
 }
 
-func (h HashFn) ComplexVectorHTP(series SeriesHTR, length uint64, index Gindex) ([]Root, error) {
+func (h HashFn) ComplexVectorHTP(series SeriesHTP, length uint64, index Gindex) []Root {
 	// length is alos limit for vectors
-	return MerkleProof(h, length, length, index, h.SeriesRootFunc(series))
+	rootSeries := func(i uint64) HTR {
+		return series(i)
+	}
+	return MerkleProof(h, length, length, index, h.SeriesRootFunc(rootSeries), h.SeriesProofFunc(series))
 }
 
 func (h HashFn) ComplexListHTR(series SeriesHTR, length uint64, limit uint64) Root {
 	return h.Mixin(Merkleize(h, length, limit, h.SeriesRootFunc(series)), length)
 }
 
-func (h HashFn) ComplexListHTP(series SeriesHTR, length uint64, limit uint64, index Gindex) ([]Root, error) {
+func (h HashFn) ComplexListHTP(series SeriesHTP, length uint64, limit uint64, index Gindex) []Root {
 	if !index.IsLeft() {
-		return nil, fmt.Errorf("gindex %d is not left, cannot get proof", index)
+		return nil
 	}
-	proof, err := MerkleProof(h, length, limit, index.Subtree(), h.SeriesRootFunc(series))
-	if err != nil {
-		return nil, err
+	rootSeries := func(i uint64) HTR {
+		return series(i)
 	}
+	proof := MerkleProof(h, length, limit, index.Subtree(), h.SeriesRootFunc(rootSeries), h.SeriesProofFunc(series))
 	return h.ProofMixin(proof, length)
 }
 
@@ -84,10 +133,10 @@ func (h HashFn) Mixin(v Root, length uint64) Root {
 	return h(v, mixin)
 }
 
-func (h HashFn) ProofMixin(p []Root, length uint64) ([]Root, error) {
+func (h HashFn) ProofMixin(p []Root, length uint64) []Root {
 	var mixin Root
 	binary.LittleEndian.PutUint64(mixin[:], length)
-	return append([]Root{h(p[0], mixin), mixin}, p[1:]...), nil
+	return append(p[:len(p)-1], mixin, h(p[0], mixin))
 }
 
 // ChunksHTR is like SeriesHTR, except that the items are chunked by the input,
@@ -97,65 +146,123 @@ func (h HashFn) ChunksHTR(chunks ChunksHTR, length uint64, limit uint64) Root {
 	return Merkleize(h, length, limit, chunks)
 }
 
-func (h HashFn) Uint8VectorHTR(v func(i uint64) uint8, length uint64) Root {
-	// 32 items per chunk
-	chunks := (length + 31) >> 5
-	return h.ChunksHTR(func(i uint64) (out Root) {
+// ChunksHTR is like SeriesHTR, except that the items are chunked by the input,
+// and chunks are merely merkleized to get the hash-tree-root.
+// No length mixin is performed (required for a list/basic-list/bitlist hash-tree-root).
+func (h HashFn) ChunksHTP(rootChunks ChunksHTR, proofChunks ChunksHTP, length uint64, limit uint64, index Gindex) []Root {
+	return MerkleProof(h, length, limit, index, rootChunks, proofChunks)
+}
+
+// Uint8
+
+func Uint8Chunks(v func(i uint64) uint8, length uint64) func(i uint64) Root {
+	return func(i uint64) (out Root) {
 		for x, j := 0, i<<5; x < 32 && j < length; j, x = j+1, x+1 {
 			out[x] = v(j)
 		}
 		return
-	}, chunks, chunks)
+	}
+}
+
+// 32 items per chunk
+func Uint8ChunkCount(length uint64) uint64 { return (length + 31) >> 5 }
+
+func (h HashFn) Uint8VectorHTR(v func(i uint64) uint8, length uint64) Root {
+	return h.ChunksHTR(
+		Uint8Chunks(v, length), Uint8ChunkCount(length), Uint8ChunkCount(length),
+	)
+}
+
+func (h HashFn) Uint8VectorHTP(v func(i uint64) uint8, length uint64, index Gindex) []Root {
+	return h.ChunksHTP(
+		Uint8Chunks(v, length), NilProofFunc, Uint8ChunkCount(length), Uint8ChunkCount(length), index,
+	)
 }
 
 func (h HashFn) Uint8ListHTR(v func(i uint64) uint8, length uint64, limit uint64) Root {
-	// 32 items per chunk
-	chunks := (length + 31) >> 5
-	return h.Mixin(h.ChunksHTR(func(i uint64) (out Root) {
-		for x, j := 0, i<<5; x < 32 && j < length; j, x = j+1, x+1 {
-			out[x] = v(j)
-		}
-		return
-	}, chunks, (limit+31)>>5), length)
+	return h.Mixin(h.ChunksHTR(
+		Uint8Chunks(v, length), Uint8ChunkCount(length), Uint8ChunkCount(limit),
+	), length)
 }
 
-func (h HashFn) Uint64VectorHTR(v func(i uint64) uint64, length uint64) Root {
-	// 4 items per chunk
-	chunks := (length + 3) >> 2
-	return h.ChunksHTR(func(i uint64) (out Root) {
+func (h HashFn) Uint8ListHTP(v func(i uint64) uint8, length uint64, limit uint64, index Gindex) []Root {
+	return h.ProofMixin(h.ChunksHTP(
+		Uint8Chunks(v, length), NilProofFunc, Uint8ChunkCount(length), Uint8ChunkCount(limit), index,
+	), length)
+}
+
+// Uint64
+
+func Uint64Chunks(v func(i uint64) uint64, length uint64) func(i uint64) Root {
+	return func(i uint64) (out Root) {
 		for x, j := 0, i<<2; x < 32 && j < length; j, x = j+1, x+8 {
 			binary.LittleEndian.PutUint64(out[x:], v(j))
 		}
 		return
-	}, chunks, chunks)
+	}
+}
+
+// 4 items per chunk
+func Uint64ChunkCount(length uint64) uint64 { return (length + 3) >> 2 }
+
+func (h HashFn) Uint64VectorHTR(v func(i uint64) uint64, length uint64) Root {
+	return h.ChunksHTR(
+		Uint64Chunks(v, length), Uint64ChunkCount(length), Uint64ChunkCount(length),
+	)
+}
+
+func (h HashFn) Uint64VectorHTP(v func(i uint64) uint64, length uint64, index Gindex) []Root {
+	return h.ChunksHTP(
+		Uint64Chunks(v, length), NilProofFunc, Uint64ChunkCount(length), Uint64ChunkCount(length), index,
+	)
 }
 
 func (h HashFn) Uint64ListHTR(v func(i uint64) uint64, length uint64, limit uint64) Root {
-	// 4 items per chunk
-	chunks := (length + 3) >> 2
-	return h.Mixin(h.ChunksHTR(func(i uint64) (out Root) {
-		for x, j := 0, i<<2; x < 32 && j < length; j, x = j+1, x+8 {
-			binary.LittleEndian.PutUint64(out[x:], v(j))
-		}
-		return
-	}, chunks, (limit+3)>>2), length)
+	return h.Mixin(h.ChunksHTR(
+		Uint64Chunks(v, length), Uint64ChunkCount(length), Uint64ChunkCount(limit),
+	), length)
 }
 
-func (h HashFn) ByteVectorHTR(values []byte) Root {
-	chunks := (uint64(len(values)) + 31) / 32
-	return h.ChunksHTR(func(i uint64) (out Root) {
+func (h HashFn) Uint64ListHTP(v func(i uint64) uint64, length uint64, limit uint64, index Gindex) []Root {
+	return h.ProofMixin(h.ChunksHTP(
+		Uint64Chunks(v, length), NilProofFunc, Uint64ChunkCount(length), Uint64ChunkCount(limit), index,
+	), length)
+}
+
+// Byte
+
+func ByteChunks(values []byte) func(i uint64) Root {
+	return func(i uint64) (out Root) {
 		copy(out[:], values[i<<5:])
 		return
-	}, chunks, chunks)
+	}
+}
+
+func ByteChunkCount(values []byte) uint64 { return (uint64(len(values)) + 31) / 32 }
+func ByteChunkLimit(limit uint64) uint64  { return (limit + 31) / 32 }
+
+func (h HashFn) ByteVectorHTR(values []byte) Root {
+	return h.ChunksHTR(
+		ByteChunks(values), ByteChunkCount(values), ByteChunkCount(values),
+	)
+}
+
+func (h HashFn) ByteVectorHTP(values []byte, index Gindex) []Root {
+	return h.ChunksHTP(
+		ByteChunks(values), NilProofFunc, ByteChunkCount(values), ByteChunkCount(values), index,
+	)
 }
 
 func (h HashFn) ByteListHTR(values []byte, limit uint64) Root {
-	chunks := (uint64(len(values)) + 31) / 32
-	chunkLimit := (limit + 31) / 32
-	return h.Mixin(h.ChunksHTR(func(i uint64) (out Root) {
-		copy(out[:], values[i<<5:])
-		return
-	}, chunks, chunkLimit), uint64(len(values)))
+	return h.Mixin(h.ChunksHTR(
+		ByteChunks(values), ByteChunkCount(values), ByteChunkLimit(limit),
+	), uint64(len(values)))
+}
+
+func (h HashFn) ByteListHTP(values []byte, limit uint64, index Gindex) []Root {
+	return h.ProofMixin(h.ChunksHTP(
+		ByteChunks(values), NilProofFunc, ByteChunkCount(values), ByteChunkLimit(limit), index,
+	), uint64(len(values)))
 }
 
 func (h HashFn) BitVectorHTR(bits []byte) Root {
@@ -169,6 +276,19 @@ func (h HashFn) BitVectorHTR(bits []byte) Root {
 		}
 		return
 	}, chunks, chunks)
+}
+
+func (h HashFn) BitVectorHTP(bits []byte, index Gindex) []Root {
+	// it's a vector, chunks is also chunkLimit.
+	// The bits are already packed in bytes, just divide by 32 (rounding up).
+	chunks := (uint64(len(bits)) + 31) / 32
+	return h.ChunksHTP(func(i uint64) (out Root) {
+		if i < chunks {
+			copy(out[:], bits[i<<5:])
+			// no delimiter bits in bit vectors
+		}
+		return
+	}, NilProofFunc, chunks, chunks, index)
 }
 
 func (h HashFn) BitListHTR(bits []byte, bitlimit uint64) Root {
@@ -185,6 +305,22 @@ func (h HashFn) BitListHTR(bits []byte, bitlimit uint64) Root {
 		}
 		return
 	}, chunks, chunkLimit), bitLen)
+}
+
+func (h HashFn) BitListHTP(bits []byte, bitlimit uint64, index Gindex) []Root {
+	bitLen := bitfields.BitlistLen(bits)
+	chunks := (bitLen + 0xff) >> 8
+	chunkLimit := (bitlimit + 0xff) >> 8
+	return h.ProofMixin(h.ChunksHTP(func(i uint64) (out Root) {
+		if i < chunks {
+			copy(out[:], bits[i<<5:])
+			// mask out delimit bit if necessary
+			if ((i + 1) << 8) > bitLen {
+				out[(bitLen&0xff)>>3] &^= 1 << (bitLen & 0x7)
+			}
+		}
+		return
+	}, NilProofFunc, chunks, chunkLimit, index), bitLen)
 }
 
 func (h HashFn) Union(selector uint8, value HTR) Root {

--- a/tree/hashing.go
+++ b/tree/hashing.go
@@ -52,28 +52,6 @@ func (h HashFn) HashTreeProof(index Gindex, fields ...HTP) []Root {
 	})
 }
 
-type rootProof struct {
-	Root *Root
-}
-
-func (r rootProof) HashTreeRoot(_ HashFn) Root {
-	if r.Root == nil {
-		return Root{}
-	}
-	return *r.Root
-}
-
-func (r rootProof) HashTreeProof(_ HashFn, _ Gindex) []Root {
-	return nil
-}
-
-func RootProof(root *Root) HTP {
-	if root == nil {
-		root = &Root{}
-	}
-	return rootProof{root}
-}
-
 func NilProofFunc(_ uint64, _ Gindex) []Root {
 	// Used for structures that we cannot recurse into, like a list of bytes.
 	return nil

--- a/tree/hashing.go
+++ b/tree/hashing.go
@@ -53,7 +53,8 @@ func (h HashFn) HashTreeProof(index Gindex, fields ...HTP) []Root {
 }
 
 func NilProofFunc(_ uint64, _ Gindex) []Root {
-	// Used for structures that we cannot recurse into, like a list of bytes.
+	// Used for structures that we cannot recurse into one of its elements, like a list of bytes,
+	// where we can return the proof branch but we cannot recurse into the bytes.
 	return nil
 }
 

--- a/tree/merkle.go
+++ b/tree/merkle.go
@@ -64,7 +64,7 @@ func Merkleize(hasher HashFn, count uint64, limit uint64, leaf func(i uint64) Ro
 }
 
 // Compute the merkle proof of the given leaf index.
-func MerkleProof(hasher HashFn, count uint64, limit uint64, index uint64, leaf func(i uint64) Root) (out []Root) {
+func MerkleProof(hasher HashFn, count uint64, limit uint64, gIndexComplete Gindex, leaf func(i uint64) Root) (out []Root, err error) {
 	if count > limit {
 		// merkleizing list that is too large, over limit
 		count = limit
@@ -86,7 +86,7 @@ func MerkleProof(hasher HashFn, count uint64, limit uint64, index uint64, leaf f
 
 	out = make([]Root, limitDepth+1)
 
-	gIndex, err := ToGindex64(index, limitDepth)
+	gIndex, gIndexFollow := gIndexComplete.Split(uint32(limitDepth))
 	if err != nil {
 		panic(err)
 	}
@@ -154,6 +154,11 @@ func MerkleProof(hasher HashFn, count uint64, limit uint64, index uint64, leaf f
 	// complement with zero-hashes at each depth.
 	for j := depth; j < limitDepth; j++ {
 		tmp[j+1] = nodeMerge(tmp[j], newNode(ZeroHashes[j], tmp[j].Gindex.Sibling()))
+	}
+
+	if !gIndexFollow.IsRoot() {
+		// TODO: Recurse into the proof of the next index
+		panic("not implemented")
 	}
 
 	return

--- a/tree/merkle.go
+++ b/tree/merkle.go
@@ -62,3 +62,99 @@ func Merkleize(hasher HashFn, count uint64, limit uint64, leaf func(i uint64) Ro
 
 	return tmp[limitDepth]
 }
+
+// Compute the merkle proof of the given leaf index.
+func MerkleProof(hasher HashFn, count uint64, limit uint64, index uint64, leaf func(i uint64) Root) (out []Root) {
+	if count > limit {
+		// merkleizing list that is too large, over limit
+		count = limit
+	}
+	if limit == 0 {
+		return
+	}
+	depth := CoverDepth(count)
+	limitDepth := CoverDepth(limit)
+	if limit == 1 {
+		out = make([]Root, 1)
+		if count == 1 {
+			out[0] = leaf(0)
+		} else {
+			out[0] = ZeroHashes[0]
+		}
+		return
+	}
+
+	out = make([]Root, limitDepth+1)
+
+	gIndex, err := ToGindex64(index, limitDepth)
+	if err != nil {
+		panic(err)
+	}
+
+	type node struct {
+		Root
+		Gindex
+	}
+	newNode := func(r Root, g Gindex) *node {
+		// Save the proof if necessary
+		if g.IsProof(gIndex) {
+			out[g.Depth()] = r
+		}
+		return &node{r, g}
+	}
+	newLeafNode := func(i uint64) *node {
+		leafGIndex, _ := ToGindex64(i, limitDepth)
+		if i >= count {
+			return newNode(ZeroHashes[0], leafGIndex)
+		} else {
+			return newNode(leaf(i), leafGIndex)
+		}
+	}
+	nodeMerge := func(n1, n2 *node) *node {
+		return newNode(hasher(n1.Root, n2.Root), n1.Parent())
+	}
+
+	tmp := make([]*node, limitDepth+1)
+	j := uint8(0)
+	hArr := &node{}
+
+	merge := func(i uint64) {
+		// merge back up from bottom to top, as far as we can
+		for j = 0; ; j++ {
+			// stop merging when we are in the left side of the next combi
+			if i&(uint64(1)<<j) == 0 {
+				// if we are at the count, we want to merge in zero-hashes for padding
+				if i == count && j < depth {
+					hArr = nodeMerge(hArr, newNode(ZeroHashes[j], hArr.Gindex.Sibling()))
+				} else {
+					break
+				}
+			} else {
+				// keep merging up if we are the right side
+				hArr = nodeMerge(tmp[j], hArr)
+			}
+		}
+		// store the merge result (may be no merge, i.e. bottom leaf node)
+		tmp[j] = hArr
+	}
+
+	// merge in leaf by leaf.
+	for i := uint64(0); i < count; i++ {
+		hArr = newLeafNode(i)
+		merge(i)
+	}
+
+	// complement with 0 if empty, or if not the right power of 2
+	if (uint64(1) << depth) != count {
+		hArr = newLeafNode(count)
+		merge(count)
+	}
+
+	// the next power of two may be smaller than the ultimate virtual size,
+	// complement with zero-hashes at each depth.
+	for j := depth; j < limitDepth; j++ {
+		tmp[j+1] = nodeMerge(tmp[j], newNode(ZeroHashes[j], tmp[j].Gindex.Sibling()))
+	}
+
+	return
+}

--- a/tree/merkle_test.go
+++ b/tree/merkle_test.go
@@ -13,10 +13,13 @@ func TestMerkleProof(t *testing.T) {
 		binary.BigEndian.PutUint64(out[24:], i+1)
 		return out
 	}
+	proofs := func(i uint64, gIndex Gindex) []Root {
+		return nil
+	}
 	tests := []struct {
 		count    uint64
 		limit    uint64
-		index    Gindex64
+		index    uint64
 		expected []string
 	}{
 		{8, 8, 0, []string{
@@ -82,10 +85,11 @@ func TestMerkleProof(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			got, err := MerkleProof(Hash, test.count, test.limit, test.index, leaf)
+			gindex, err := ToGindex64(test.index, CoverDepth(test.limit))
 			if err != nil {
 				t.Fatal(err)
 			}
+			got := MerkleProof(Hash, test.count, test.limit, gindex, leaf, proofs)
 			if len(got) != len(test.expected) {
 				t.Fatalf("got %d items, expected %d", len(got), len(test.expected))
 			}

--- a/tree/merkle_test.go
+++ b/tree/merkle_test.go
@@ -16,7 +16,7 @@ func TestMerkleProof(t *testing.T) {
 	tests := []struct {
 		count    uint64
 		limit    uint64
-		index    uint64
+		index    Gindex64
 		expected []string
 	}{
 		{8, 8, 0, []string{
@@ -82,7 +82,10 @@ func TestMerkleProof(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			got := MerkleProof(Hash, test.count, test.limit, test.index, leaf)
+			got, err := MerkleProof(Hash, test.count, test.limit, test.index, leaf)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if len(got) != len(test.expected) {
 				t.Fatalf("got %d items, expected %d", len(got), len(test.expected))
 			}

--- a/tree/merkle_test.go
+++ b/tree/merkle_test.go
@@ -1,0 +1,104 @@
+package tree
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+)
+
+func TestMerkleProof(t *testing.T) {
+	leaf := func(i uint64) Root {
+		out := Root{}
+		binary.BigEndian.PutUint64(out[24:], i+1)
+		return out
+	}
+	tests := []struct {
+		count    uint64
+		limit    uint64
+		index    uint64
+		expected []string
+	}{
+		{8, 8, 0, []string{
+			"f21a13e8c312a582f7a002f90b7af23bf104d4bfe70be85fe16229db8174c8f9",
+			"373fade5331b44f7c3bbde6d110d5f62a9c658029567331fb29d2df285b8456a",
+			"da0cd6b20f3f0d2e7c040ea5d411fed01cbe85af2bdc3069d7d191073b4bd2a7",
+			"0000000000000000000000000000000000000000000000000000000000000002",
+		}},
+
+		{8, 9, 0, []string{
+			"933df3778817647f2cedb0b2a43e15b2a27b138f7050132fa3d6f5ef5141c55a",
+			"c78009fdf07fc56a11f122370658a353aaa542ed63e44c4bc15ff4cd105ab33c",
+			"373fade5331b44f7c3bbde6d110d5f62a9c658029567331fb29d2df285b8456a",
+			"da0cd6b20f3f0d2e7c040ea5d411fed01cbe85af2bdc3069d7d191073b4bd2a7",
+			"0000000000000000000000000000000000000000000000000000000000000002",
+		}},
+		{9, 9, 8, []string{
+			"b00c4fa7e5c2f468627398409af7bc6fb364c8bbcf629d58ae74385e08aee694",
+			"f21a13e8c312a582f7a002f90b7af23bf104d4bfe70be85fe16229db8174c8f9",
+			"db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71",
+			"f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b",
+			"0000000000000000000000000000000000000000000000000000000000000000",
+		}},
+		{6, 1024, 0, []string{
+			"f6b1035624bd2bb134a52924e41d66c8e31177458809de4ac8a2b0ac2ae1cd41",
+			"506d86582d252405b840018792cad2bf1259f1ef5aa5f887e13cb2f0094f51e1",
+			"26846476fd5fc54a5d43385167c95144f2643f533cc85bb9d16b782f8d7db193",
+			"87eb0ddba57e35f6d286673802a4af5975e22506c7cf4c64bb6be5ee11527f2c",
+			"d88ddfeed400a8755596b21942c1497e114c302e6118290f91e6772976041fa1",
+			"9efde052aa15429fae05bad4d0b1d7c64da64d03d7a1854a588c2cb8430c0d30",
+			"536d98837f2dd165a55d5eeae91485954472d56f246df256bf3cae19352a123c",
+			"c78009fdf07fc56a11f122370658a353aaa542ed63e44c4bc15ff4cd105ab33c",
+			"9f9315983e72b3712b8453057fffea967876477459f4f288a79ac135f7e7ea7f",
+			"da0cd6b20f3f0d2e7c040ea5d411fed01cbe85af2bdc3069d7d191073b4bd2a7",
+			"0000000000000000000000000000000000000000000000000000000000000002",
+		}},
+		{6, 1024, 1, []string{
+			"f6b1035624bd2bb134a52924e41d66c8e31177458809de4ac8a2b0ac2ae1cd41",
+			"506d86582d252405b840018792cad2bf1259f1ef5aa5f887e13cb2f0094f51e1",
+			"26846476fd5fc54a5d43385167c95144f2643f533cc85bb9d16b782f8d7db193",
+			"87eb0ddba57e35f6d286673802a4af5975e22506c7cf4c64bb6be5ee11527f2c",
+			"d88ddfeed400a8755596b21942c1497e114c302e6118290f91e6772976041fa1",
+			"9efde052aa15429fae05bad4d0b1d7c64da64d03d7a1854a588c2cb8430c0d30",
+			"536d98837f2dd165a55d5eeae91485954472d56f246df256bf3cae19352a123c",
+			"c78009fdf07fc56a11f122370658a353aaa542ed63e44c4bc15ff4cd105ab33c",
+			"9f9315983e72b3712b8453057fffea967876477459f4f288a79ac135f7e7ea7f",
+			"da0cd6b20f3f0d2e7c040ea5d411fed01cbe85af2bdc3069d7d191073b4bd2a7",
+			"0000000000000000000000000000000000000000000000000000000000000001",
+		}},
+		{6, 1023, 1, []string{
+			"f6b1035624bd2bb134a52924e41d66c8e31177458809de4ac8a2b0ac2ae1cd41",
+			"506d86582d252405b840018792cad2bf1259f1ef5aa5f887e13cb2f0094f51e1",
+			"26846476fd5fc54a5d43385167c95144f2643f533cc85bb9d16b782f8d7db193",
+			"87eb0ddba57e35f6d286673802a4af5975e22506c7cf4c64bb6be5ee11527f2c",
+			"d88ddfeed400a8755596b21942c1497e114c302e6118290f91e6772976041fa1",
+			"9efde052aa15429fae05bad4d0b1d7c64da64d03d7a1854a588c2cb8430c0d30",
+			"536d98837f2dd165a55d5eeae91485954472d56f246df256bf3cae19352a123c",
+			"c78009fdf07fc56a11f122370658a353aaa542ed63e44c4bc15ff4cd105ab33c",
+			"9f9315983e72b3712b8453057fffea967876477459f4f288a79ac135f7e7ea7f",
+			"da0cd6b20f3f0d2e7c040ea5d411fed01cbe85af2bdc3069d7d191073b4bd2a7",
+			"0000000000000000000000000000000000000000000000000000000000000001",
+		}},
+	}
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			got := MerkleProof(Hash, test.count, test.limit, test.index, leaf)
+			if len(got) != len(test.expected) {
+				t.Fatalf("got %d items, expected %d", len(got), len(test.expected))
+			}
+			root := Merkleize(Hash, test.count, test.limit, leaf)
+			if !bytes.Equal(root[:], got[0][:]) {
+				t.Errorf("unexpected root, got %x, expected %x", got[len(got)-1][:], root[:])
+			}
+			for i, v := range got {
+				expectedBytes, err := hex.DecodeString(test.expected[i])
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(v[:], expectedBytes) {
+					t.Errorf("at index %d, got %x, expected %x", i, v[:], expectedBytes[:])
+				}
+			}
+		})
+	}
+}

--- a/tree/root.go
+++ b/tree/root.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+
 	"github.com/protolambda/ztyp/codec"
 	"github.com/protolambda/ztyp/conv"
 )
@@ -44,6 +45,11 @@ func (Root) ValueByteLength() (uint64, error) {
 
 func (r Root) HashTreeRoot(_ HashFn) Root {
 	return r
+}
+
+func (r Root) HashTreeProof(_ HashFn, index Gindex) []Root {
+	// We can't descend into the root
+	return nil
 }
 
 func (r *Root) UnmarshalText(text []byte) error {

--- a/view/basic.go
+++ b/view/basic.go
@@ -4,10 +4,11 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"strconv"
+
 	"github.com/protolambda/ztyp/codec"
 	"github.com/protolambda/ztyp/conv"
 	. "github.com/protolambda/ztyp/tree"
-	"strconv"
 )
 
 // A uint type, identified by its size in bytes.
@@ -602,6 +603,10 @@ func (v Uint64View) HashTreeRoot(h HashFn) Root {
 	newRoot := Root{}
 	binary.LittleEndian.PutUint64(newRoot[:], uint64(v))
 	return newRoot
+}
+
+func (v Uint64View) HashTreeProof(h HashFn, _ Gindex) []Root {
+	return nil
 }
 
 func (v Uint64View) Type() TypeDef {

--- a/view/basic.go
+++ b/view/basic.go
@@ -822,6 +822,10 @@ func (v BoolView) HashTreeRoot(h HashFn) Root {
 	return newRoot
 }
 
+func (v BoolView) HashTreeProof(h HashFn, index Gindex) []Root {
+	return nil
+}
+
 func (v BoolView) Type() TypeDef {
 	return BoolType
 }

--- a/view/u256.go
+++ b/view/u256.go
@@ -3,12 +3,13 @@ package view
 import (
 	"encoding/binary"
 	"fmt"
+	"math/big"
+	"strconv"
+
 	"github.com/holiman/uint256"
 	"github.com/protolambda/ztyp/codec"
 	"github.com/protolambda/ztyp/conv"
 	. "github.com/protolambda/ztyp/tree"
-	"math/big"
-	"strconv"
 )
 
 type Uint256View uint256.Int
@@ -113,6 +114,10 @@ func (v *Uint256View) Decode(x []byte) error {
 
 func (v Uint256View) HashTreeRoot(h HashFn) Root {
 	return v.Bytes32()
+}
+
+func (v Uint256View) HashTreeProof(h HashFn, index Gindex) []Root {
+	return nil
 }
 
 func (v Uint256View) Type() TypeDef {


### PR DESCRIPTION
Adds routine to generate merkle proofs in preparation to be able to generate blob sidecars in accordance to https://github.com/ethereum/consensus-specs/pull/3531

Also adds the generic proof interfaces in order to be able to recursively obtain a proof of a sub-element.

E.g. if we have an object of type `BeaconBlockBody` which has a field of type `BlobKZGCommitments`, and both types implement `HashTreeProof`, it is now possible to obtain a proof branch of an element of `BlobKZGCommitments` from the leaf of the element all the way to the root of `BeaconBlockBody`.

I've implemented methods for most types in zrnt and ran the static tests included in https://github.com/ethereum/consensus-specs/pull/3531 and they are passing when the proofs are calculated by using the methods implemented in this PR.